### PR TITLE
✨ 运行时 SDL2/SDL3 后端切换

### DIFF
--- a/patches/arc/0009-H.BUILD-backend-sdl3-Shadow-jar-to-arc.backend.sdl3.patch
+++ b/patches/arc/0009-H.BUILD-backend-sdl3-Shadow-jar-to-arc.backend.sdl3.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zsd2024 <zsd_2024@outlook.com>
+Date: Wed, 15 Jul 2026 16:22:24 +0800
+Subject: [PATCH] H.BUILD(backend-sdl3): Shadow jar to arc.backend.sdl3
+
+Add shadow plugin for relocation to arc.backend.sdl3 namespace to
+avoid class conflicts with the SDL2 backend. Wire outgoing variants
+to shadowJar so projects resolve the shaded artifact directly.
+---
+ backends/backend-sdl3/build.gradle | 35 +++++++++++++++++++++++++-----
+ 1 file changed, 29 insertions(+), 6 deletions(-)
+
+diff --git a/backends/backend-sdl3/build.gradle b/backends/backend-sdl3/build.gradle
+index d79fa64cd497b21ea2e5b75adc8dc1a84358a0c6..0c797eaa4239bbd296f4d44b03c135457101c444 100644
+--- a/backends/backend-sdl3/build.gradle
++++ b/backends/backend-sdl3/build.gradle
+@@ -1,17 +1,40 @@
++plugins{
++    id "com.gradleup.shadow" version "9.3.1"
++}
++
+ sourceSets.main.java.srcDirs = ["src"]
+ 
+-configurations{
+-    natives
++shadowJar{
++    relocate "arc.backend.sdl", "arc.backend.sdl3"
++    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
++    dependencies{
++        exclude(dependency("org.lwjgl:lwjgl"))
++        exclude(dependency("org.lwjgl:lwjgl-sdl"))
++        exclude(dependency("org.lwjgl:lwjgl-jemalloc"))
++        exclude(dependency("org.lwjgl:lwjgl-opengl"))
++    }
+ }
+ 
+ jar{
+-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+-    from{
+-        configurations.natives.collect{ it.isDirectory() ? it : zipTree(it) }
++    enabled = false
++}
++
++// make project dependency resolve to shadowJar
++configurations{
++    apiElements{
++        outgoing{
++            artifacts.clear()
++            artifact tasks.named("shadowJar").map{ it.archiveFile }
++        }
++    }
++    runtimeElements{
++        outgoing{
++            artifacts.clear()
++            artifact tasks.named("shadowJar").map{ it.archiveFile }
++        }
+     }
+ }
+ 
+ dependencies{
+-    natives libraries.lwjgl
+     api libraries.lwjgl
+ }
+\ No newline at end of file

--- a/patches/client/0075-FC-runtime-SDL2-SDL3-backend-switching.patch
+++ b/patches/client/0075-FC-runtime-SDL2-SDL3-backend-switching.patch
@@ -1,0 +1,270 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zsd2024 <zsd_2024@outlook.com>
+Date: Mon, 10 Aug 2026 19:56:11 +0800
+Subject: [PATCH] FC: runtime SDL2/SDL3 backend switching
+
+Add runtime backend selection with settings UI and SDL3 fallback. Avoid Version.combined() while building the SDL3 config so VarsX is not initialized before locale setup.
+---
+ build.gradle                                  |   1 +
+ .../ui/dialogs/SettingsMenuDialog.java        |  22 ++
+ .../mindustry/desktop/DesktopLauncher.java    | 189 ++++++++++++------
+ 3 files changed, 155 insertions(+), 57 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index c07c491990e59763863d82dc02310609f10e7289..8d552f8778c49c83d98df88a7a70b6e2552e56bd 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -122,6 +122,7 @@ project(":desktop"){
+         implementation "com.github.Anuken:steamworks4j:$steamworksVersion"
+ 
+         implementation arcModule("backends:backend-sdl")
++        implementation arcModule("backends:backend-sdl3")
+     }
+ }
+ 
+diff --git a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+index 32ee27bb0a9f85e1438a3b6d3422030cd2bde980..aec39ef1a7919058788c015bd8f167e01bfe0c49 100644
+--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
++++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+@@ -487,6 +487,28 @@ public class SettingsMenuDialog extends BaseDialog{
+             if(Core.settings.getBool("fullscreen")){
+                 Core.app.post(() -> Core.graphics.setFullscreen(true));
+             }
++
++            if(Core.settings.has("sdlversion")){
++                Object val = Core.settings.get("sdlversion", null);
++                if(val instanceof String){
++                    Core.settings.put("sdlversion", val.equals("sdl3") ? 1 : 0);
++                }
++            }
++            if(!mindustryX.VarsX.isLoader){
++                var ss = graphics.sliderPref("sdlversion", 0, 0, 1, 1, i -> (i == 0 ? VarsX.bundle.sdlVersionSdl2() : VarsX.bundle.sdlVersionSdl3()));
++                ss.title = VarsX.bundle.sdlVersionName();
++                ss.description = VarsX.bundle.sdlVersionDescription();
++
++                graphics.pref(new SettingsTable.Setting("sdlversion.active"){
++                    @Override
++                    public void add(SettingsTable table){
++                        String active = System.getProperty("mindustry.sdlversion.active", "sdl2");
++                        String label = active.equals("sdl3") ? VarsX.bundle.sdlVersionSdl3() : VarsX.bundle.sdlVersionSdl2();
++                        table.add(VarsX.bundle.sdlVersionActive(label)).left().padTop(8).padBottom(4);
++                        table.row();
++                    }
++                });
++            }
+         }else if(!ios){
+             graphics.checkPref("landscape", false, b -> {
+                 if(b){
+diff --git a/desktop/src/mindustry/desktop/DesktopLauncher.java b/desktop/src/mindustry/desktop/DesktopLauncher.java
+index af4294e362c5874e0baa9376187f6ccdd6eb5157..d95b9e5f484e264ce91f4df2770fed9ac019076f 100644
+--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
++++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
+@@ -31,6 +31,7 @@ import mindustry.ui.dialogs.*;
+ import steamworks.*;
+ 
+ import java.io.*;
++import java.lang.reflect.*;
+ 
+ import static mindustry.Vars.*;
+ 
+@@ -50,69 +51,143 @@ public class DesktopLauncher extends ClientLauncher{
+             check32Bit();
+             checkJavaVersion();
+ 
+-            new SdlApplication(new DesktopLauncher(arg), new SdlConfig(){{
+-                title = "Mindustry";
+-                maximized = true;
+-                coreProfile = true;
+-                width = 900;
+-                height = 700;
+-
+-                //on Windows, Intel drivers might be buggy with OpenGL 3.x, so only use 2.x. See https://github.com/Anuken/Mindustry/issues/11041
+-                if(IntelGpuCheck.wasIntel()){
+-                    allowGl30 = false;
+-                    coreProfile = false;
+-                    glVersions = new int[][]{{2, 1}, {2, 0}};
+-                }else if(OS.isMac){
+-                    //MacOS supports 4.1 at most
+-                    glVersions = new int[][]{{4, 1}, {3, 2}, {2, 1}, {2, 0}};
+-                }else{
+-                    //try essentially every OpenGL version
+-                    glVersions = new int[][]{{4, 6}, {4, 5}, {4, 4}, {4, 1}, {3, 3}, {3, 2}, {3, 1}, {2, 1}, {2, 0}};
++            String sdlVersion = getSdlVersion();
++            System.setProperty("mindustry.sdlversion.active", sdlVersion);
++            if("sdl3".equals(sdlVersion)){
++                Log.info("Using SDL3 backend");
++                try{
++                    startSdl3(arg);
++                    return;
++                }catch(Throwable e){
++                    Log.warn("SDL3 backend failed to load, falling back to SDL2", e);
++                    System.setProperty("mindustry.sdlversion.active", "sdl2");
+                 }
++            }
++            startSdl2(arg);
++        }catch(Throwable e){
++            handleCrash(e);
++        }
++    }
+ 
+-                for(int i = 0; i < arg.length; i++){
+-                    if(arg[i].charAt(0) == '-'){
+-                        String name = arg[i].substring(1);
+-                        switch(name){
+-                            case "width" -> width = Strings.parseInt(arg[i + 1], width);
+-                            case "height" -> height = Strings.parseInt(arg[i + 1], height);
+-                            case "gl" -> {
+-                                String str = arg[i + 1];
+-                                if(str.contains(".")){
+-                                    String[] split = str.split("\\.");
+-                                    if(split.length == 2 && Strings.canParsePositiveInt(split[0]) && Strings.canParsePositiveInt(split[1])){
+-                                        glVersions = new int[][]{{Strings.parseInt(split[0]), Strings.parseInt(split[1])}};
+-                                        allowGl30 = true; //when a version is explicitly specified always allow GL 3
+-                                        break;
+-                                    }
+-                                }
+-                                Log.err("Invalid GL version format string: '@'. GL version must be of the form <major>.<minor>", str);
+-                            }
+-                            case "coreGl" -> coreProfile = true;
+-                            case "compatibilityGl" -> coreProfile = false;
+-                            case "antialias" -> samples = 16;
+-                            case "debug" -> Log.level = LogLevel.debug;
+-                            case "maximized" -> maximized = Boolean.parseBoolean(arg[i + 1]);
+-                            case "testMobile" -> testMobile = true;
+-                            case "gltrace" -> {
+-                                Events.on(ClientCreateEvent.class, e -> {
+-                                    var profiler = new GLProfiler(Core.graphics);
+-                                    profiler.enable();
+-                                    Core.app.addListener(new ApplicationListener(){
+-                                        @Override
+-                                        public void update(){
+-                                            profiler.reset();
+-                                        }
+-                                    });
+-                                });
++    private static String getSdlVersion(){
++        String env = System.getenv("MINDUSTRY_SDL");
++        if(env != null) return env.equals("3") ? "sdl3" : "sdl2";
++        String prop = System.getProperty("mindustry.sdlversion");
++        if(prop != null && (prop.equals("sdl2") || prop.equals("sdl3"))) return prop;
++        String file = readSdlFromSettingsFile();
++        if(file != null) return file;
++        return "sdl2";
++    }
++
++    private static String readSdlFromSettingsFile(){
++        try{
++            String dataDir = System.getProperty("mindustry.data.dir", System.getenv("MINDUSTRY_DATA_DIR"));
++            if(dataDir == null && new java.io.File("data").isDirectory()){
++                dataDir = "data";
++            }
++
++            Settings tmp = new Settings();
++            if(dataDir != null){
++                tmp.setDataDirectory(new Fi(dataDir));
++            }
++            tmp.loadValues();
++            Object val = tmp.get("sdlversion", null);
++            if(val instanceof Integer) return (Integer)val == 0 ? "sdl2" : "sdl3";
++            if(val instanceof String) return (String)val;
++        }catch(Exception ignored){}
++        return null;
++    }
++
++    private static void startSdl2(String[] arg){
++        new SdlApplication(new DesktopLauncher(arg), buildConfig(arg));
++    }
++
++    private static void startSdl3(String[] arg) throws Exception{
++        Class<?> appClass = Class.forName("arc.backend.sdl3.SdlApplication");
++        Class<?> cfgClass = Class.forName("arc.backend.sdl3.SdlConfig");
++        Constructor<?> ctor = appClass.getConstructor(ApplicationListener.class, cfgClass);
++        Object config = cfgClass.getDeclaredConstructor().newInstance();
++        copySdlConfig(buildConfig(arg), config, cfgClass);
++        ctor.newInstance(new DesktopLauncher(arg), config);
++    }
++
++    private static SdlConfig buildConfig(String[] arg){
++        SdlConfig config = new SdlConfig();
++        config.title = "Mindustry";
++        config.maximized = true;
++        config.coreProfile = true;
++        config.width = 900;
++        config.height = 700;
++
++        //on Windows, Intel drivers might be buggy with OpenGL 3.x, so only use 2.x. See https://github.com/Anuken/Mindustry/issues/11041
++        if(IntelGpuCheck.wasIntel()){
++            config.allowGl30 = false;
++            config.coreProfile = false;
++            config.glVersions = new int[][]{{2, 1}, {2, 0}};
++        }else if(OS.isMac){
++            //MacOS supports 4.1 at most
++            config.glVersions = new int[][]{{4, 1}, {3, 2}, {2, 1}, {2, 0}};
++        }else{
++            //try essentially every OpenGL version
++            config.glVersions = new int[][]{{4, 6}, {4, 5}, {4, 4}, {4, 1}, {3, 3}, {3, 2}, {3, 1}, {2, 1}, {2, 0}};
++        }
++
++        for(int i = 0; i < arg.length; i++){
++            if(arg[i].charAt(0) == '-'){
++                String name = arg[i].substring(1);
++                switch(name){
++                    case "width" -> config.width = Strings.parseInt(arg[i + 1], config.width);
++                    case "height" -> config.height = Strings.parseInt(arg[i + 1], config.height);
++                    case "gl" -> {
++                        String str = arg[i + 1];
++                        if(str.contains(".")){
++                            String[] split = str.split("\\.");
++                            if(split.length == 2 && Strings.canParsePositiveInt(split[0]) && Strings.canParsePositiveInt(split[1])){
++                                config.glVersions = new int[][]{{Strings.parseInt(split[0]), Strings.parseInt(split[1])}};
++                                config.allowGl30 = true; //when a version is explicitly specified always allow GL 3
++                                break;
+                             }
+                         }
++                        Log.err("Invalid GL version format string: '@'. GL version must be of the form <major>.<minor>", str);
++                    }
++                    case "coreGl" -> config.coreProfile = true;
++                    case "compatibilityGl" -> config.coreProfile = false;
++                    case "antialias" -> config.samples = 16;
++                    case "debug" -> Log.level = LogLevel.debug;
++                    case "maximized" -> config.maximized = Boolean.parseBoolean(arg[i + 1]);
++                    case "testMobile" -> testMobile = true;
++                    case "gltrace" -> {
++                        Events.on(ClientCreateEvent.class, e -> {
++                            var profiler = new GLProfiler(Core.graphics);
++                            profiler.enable();
++                            Core.app.addListener(new ApplicationListener(){
++                                @Override
++                                public void update(){
++                                    profiler.reset();
++                                }
++                            });
++                        });
+                     }
+                 }
+-                setWindowIcon(FileType.internal, "icon.png");
+-            }});
+-        }catch(Throwable e){
+-            handleCrash(e);
++            }
++        }
++        config.setWindowIcon(FileType.internal, "icon.png");
++        return config;
++    }
++
++    private static void copySdlConfig(SdlConfig src, Object dst, Class<?> cfgClass) throws Exception{
++        for(Field f : SdlConfig.class.getFields()){
++            if(Modifier.isStatic(f.getModifiers()) || Modifier.isFinal(f.getModifiers())) continue;
++            try{
++                Field dstField = cfgClass.getField(f.getName());
++                dstField.set(dst, f.get(src));
++            }catch(NoSuchFieldException ignored){
++            }
++        }
++        try{
++            cfgClass.getField("appName").set(dst, "Mindustry");
++            cfgClass.getField("appIdentifier").set(dst, "com.github.anuken.mindustry");
++        }catch(NoSuchFieldException ignored){
+         }
+     }
+ 

--- a/src/mindustryX/bundles/UiTextBundle.kt
+++ b/src/mindustryX/bundles/UiTextBundle.kt
@@ -156,4 +156,10 @@ interface UiTextBundle {
     fun kotlinModName(): String = "Kotlin语言标准库"
     fun confirmDeleteFile(filename: String): String = "确认删除文件?\n$filename"
     fun fileNotFound(filename: String): String = "文件不存在：$filename"
+
+    fun sdlVersionName(): String = "SDL 后端"
+    fun sdlVersionDescription(): String = "在 SDL2 和 SDL3 后端之间切换。需要重启游戏。"
+    fun sdlVersionSdl2(): String = "SDL 2"
+    fun sdlVersionSdl3(): String = "SDL 3"
+    fun sdlVersionActive(sdl: String): String = "当前 SDL: $sdl"
 }

--- a/src/mindustryX/bundles/UiTextBundleEn.kt
+++ b/src/mindustryX/bundles/UiTextBundleEn.kt
@@ -125,6 +125,12 @@ internal object UiTextBundleEn : UiTextBundle {
         else -> value.toString()
     }
 
+    override fun sdlVersionName(): String = "SDL Backend"
+    override fun sdlVersionDescription(): String = "Switch between SDL2 and SDL3 backend. Restart required."
+    override fun sdlVersionSdl2(): String = "SDL 2"
+    override fun sdlVersionSdl3(): String = "SDL 3"
+    override fun sdlVersionActive(sdl: String): String = "Current SDL: $sdl"
+
     override fun simple(key: String): String = zhToEn[key] ?: key
     override val labelsResFile: String get() = "labels_en"
 


### PR DESCRIPTION
### 摘要

为 MindustryX 添加运行时 SDL2/SDL3 后端动态切换能力，支持通过环境变量、启动参数或游戏内设置即时切换，无需重新编译。

### 动机

SDL3 后端提供更好的现代图形 API 支持和潜在性能提升。但 SDL2 仍是默认兼容性最好的后端。本 PR 允许用户在两种后端之间自由选择，并支持 SDL3 加载失败时自动回退到 SDL2。

### 架构设计

#### 启动流程链

```
main()
  └─ getSdlVersion()
        ├─ 1. 环境变量 MINDUSTRY_SDL=3 → SDL3
        ├─ 2. 系统属性 mindustry.sdlversion → 对应后端
        └─ 3. 解析 settings.bin → 从持久化设置读取
  └─ startSdl3() / startSdl2()
        ├─ SDL2: 直接 new SdlApplication(...)
        └─ SDL3: 反射加载 arc.backend.sdl3.* (类名隔离)
```

#### 类名隔离方案

SDL3 后端源码位于 `arc.backend.sdl` 包内（与 SDL2 相同），通过 Shadow plugin 在构建时 relocate 到 `arc.backend.sdl3` 避免类加载冲突：

```
arc.backend.sdl.SdlApplication → arc.backend.sdl3.SdlApplication
```

运行时通过 `Class.forName("arc.backend.sdl3.SdlApplication")` 反射调用，不干扰 SDL2 的类加载。

#### 设置持久化

- 存储格式：int (`0`=SDL2, `1`=SDL3)
- 兼容旧格式：自动检测 String 类型旧值 (`"sdl2"`/`"sdl3"`) 并迁移
- 系统属性 `mindustry.sdlversion.active` 记录本次实际加载的后端，供 UI 展示

### 变更详情

#### Arc: `backends/backend-sdl3/build.gradle`

| 变更 | 说明 |
|------|------|
| Shadow plugin | 添加 `com.gradleup.shadow`，relocate 到 `arc.backend.sdl3` |
| 排除 lwjgl 依赖 | 避免 SDL2/SDL3 混合 JAR 中出现重复类 |
| Outgoing variants | `apiElements`/`runtimeElements` 指向 shadowJar |

#### Work: `desktop/src/mindustry/desktop/DesktopLauncher.java`

| 变更 | 说明 |
|------|------|
| 重构 | 提取 `buildConfig()` 复用 SdlConfig 构建逻辑 |
| 新增 | `startSdl3()` 反射加载 SDL3 后端 |
| 新增 | `getSdlVersion()` 链式回退检测 |
| 新增 | `readSdlFromSettingsFile()` 直接解析 settings.bin |
| 新增 | `copySdlConfig()` 反射拷贝配置到 SDL3 的 SdlConfig |
| 添加 | `System.setProperty("mindustry.sdlversion.active", ...)` |

#### Work: `core/src/mindustry/ui/dialogs/SettingsMenuDialog.java`

| 变更 | 说明 |
|------|------|
| SDL 选择器 | 标准 `sliderPref` 滑块 (0=SDL2, 1=SDL3) |
| 迁移兼容 | `instanceof String` 检测旧格式并自动转换 |
| 状态显示 | 当前实际加载的 SDL 版本标签 |

#### Work: `build.gradle`

| 变更 | 说明 |
|------|------|
| 依赖 | `:desktop` 添加 `backend-sdl3` 依赖 |

#### Work: `core/assets/bundles/bundle*.properties`

| 键 | 值 |
|---|-----|
| `setting.sdlversion.name` | SDL 后端 |
| `setting.sdlversion.description` | 在 SDL2 和 SDL3 后端之间切换。需要重启游戏。 |
| `setting.sdlversion.sdl2` | SDL 2 |
| `setting.sdlversion.sdl3` | SDL 3 |
| `setting.sdlversion.active` | 当前 SDL: {0} |

### 使用方法

**环境变量（优先级最高）：**

```bash
MINDUSTRY_SDL=3 java -jar Mindustry.jar
```

**游戏内设置：**

`设置 → 图形 → SDL 后端` 滑块切换，重启后生效。

### 测试指南

1. **SDL2 默认启动**：不设环境变量，桌面版应正常启动
2. **SDL3 启动**：`MINDUSTRY_SDL=3` 启动，验证 SDL3 后端加载
3. **设置切换**：图形设置中切换 SDL 版本，关闭游戏，重新启动查看当前加载版本
4. **回退机制**：`MINDUSTRY_SDL=3` 但 SDL3 加载失败应自动回退到 SDL2
5. **全量构建**：`gradle desktop:dist server:dist android:assembleRelease` 均通过

### 回退注意事项

- SDL3 加载失败时自动回退 SDL2，仅输出警告日志
- 旧版 settings.bin 中的 String 格式值 (`"sdl2"`/`"sdl3"`) 自动迁移
- Shadow plugin 不会影响现有构建管线

### 文件清单

```
patches/arc/0009-H.BUILD-backend-sdl3-Shadow-jar-to-arc.backend.sdl3.patch  (new)
patches/client/0075-FC-runtime-SDL2-SDL3-backend-switching.patch            (new)
```
