### PR TITLE
fix: handle zero division in power bar when shouldConsume is false

### DIFF
--- a/patches/client/0030-FR-ARC-setBars.patch
+++ b/patches/client/0030-FR-ARC-setBars.patch
@@ -95,16 +95,18 @@ index 039b49606f45d196b605e63a70c6cb7d61980383..be0475c49e0d69d93196ac5da56b8d98
  
          if(consPower != null){
              boolean buffered = consPower.buffered;
-@@ -704,7 +709,11 @@ public class Block extends UnlockableContent implements Senseable{
+@@ -704,7 +709,13 @@ public class Block extends UnlockableContent implements Senseable{
  
              addBar("power", entity -> new Bar(
                  () -> buffered ? Core.bundle.format("bar.poweramount", Float.isNaN(entity.power.status * capacity) ? "<ERROR>" : UI.formatAmount((int)(entity.power.status * capacity))) :
 -                Core.bundle.get("bar.power"),
++                entity.shouldConsume() ?
 +                Iconc.power + " " + FormatDefault.percent(
-+                entity.power.status * consPower.usage * 60 * entity.timeScale() * (entity.shouldConsume() ? 1f : 0f),
-+                consPower.usage * 60 * entity.timeScale() * (entity.shouldConsume() ? 1f : 0f),
-+                entity.timeScale() * 100 * (entity.shouldConsume() ? 1f : 0f) * entity.efficiency
-+                ),
++                entity.power.status * consPower.usage * 60 * entity.timeScale(),
++                consPower.usage * 60 * entity.timeScale(),
++                entity.timeScale() * 100 * entity.efficiency
++                ) :
++                Iconc.power + " " + FormatDefault.percent(entity.power.status * 100, 100, entity.power.status, false),
                  () -> Pal.powerBar,
                  () -> Mathf.zero(consPower.requestedPower(entity)) && entity.power.graph.getPowerProduced() + entity.power.graph.getBatteryStored() > 0f ? 1f : entity.power.status)
              );


### PR DESCRIPTION
## 问题

当方块动态计算耗电且 `shouldConsume()` 返回 `false` 时，原代码分子分母都乘以 0，`FormatDefault.percent(0, 0)` 产生 `NaN`，电力条显示异常。

## 修复

用三元运算符区分两种状态：
- `shouldConsume() == true`：显示耗电比率（当前耗电 / 最大耗电），与之前行为一致
- `shouldConsume() == false`：显示 `entity.power.status` 百分比（电力充能状态），避免 0/0

## 验证

- `core:compileKotlin` + `core:compileJava` 强制重新编译通过
- 修改仅涉及 `patches/client/0030-FR-ARC-setBars.patch` 中 `Block.setBars()` 的电力条